### PR TITLE
Track SWGType and SWGStatus as state values

### DIFF
--- a/src/components/NoteContent/NoteContent.js
+++ b/src/components/NoteContent/NoteContent.js
@@ -66,6 +66,8 @@ const NoteContent = ({ annotation, isEditing, setIsEditing, noteIndex, onTextCha
   
   const dispatch = useDispatch();
   const isReply = annotation.isReply();
+  const [annotationSWGType, setAnnotationSWGType] = useState(annotation.getCustomData("SWGtype"));
+  const [annotationSWGStatus, setAnnotationSWGStatus] = useState(annotation.getCustomData("SWGstatus"));
 
   useDidUpdate(() => {
     if (!isEditing) {
@@ -100,6 +102,8 @@ const NoteContent = ({ annotation, isEditing, setIsEditing, noteIndex, onTextCha
     const annotationManager = core.getAnnotationManager();
     annotationManager.trigger('annotationChanged', [[annotation], 'modify', {}]);
     core.selectAnnotation(annotation);
+    setAnnotationSWGType(type);
+    setAnnotationSWGStatus(status);
   }, [annotation]);
 
   const renderAuthorName = useCallback(
@@ -227,7 +231,8 @@ const NoteContent = ({ annotation, isEditing, setIsEditing, noteIndex, onTextCha
           </div>
         </div>
         <SWGNoteSWGStatus
-          annotation={annotation}
+          annotationSWGType={annotationSWGType}
+          annotationSWGStatus={annotationSWGStatus}
           handleStatusChange={handleStatusChange}
           isSelected={isSelected}
         />
@@ -246,7 +251,7 @@ const NoteContent = ({ annotation, isEditing, setIsEditing, noteIndex, onTextCha
           )}
       </div>
     </React.Fragment>
-  ), [isReply, numberOfReplies, formatNumberOfReplies, icon, color, renderAuthorName, annotation, noteDateFormat, isStateDisabled, isSelected, isEditing, setIsEditing, contents, renderContents, textAreaValue, onTextChange, language, isUnread]);
+  ), [isReply, numberOfReplies, formatNumberOfReplies, icon, color, renderAuthorName, annotation, noteDateFormat, isStateDisabled, isSelected, isEditing, setIsEditing, contents, renderContents, textAreaValue, onTextChange, language, isUnread, annotationSWGType, annotationSWGStatus]);
 
 
   return useMemo(

--- a/src/components/SWGNoteSWGStatus/SWGNoteSWGStatus.js
+++ b/src/components/SWGNoteSWGStatus/SWGNoteSWGStatus.js
@@ -10,7 +10,8 @@ import core from 'core';
 import './SWGNoteSWGStatus.scss';
 
 const propTypes = {
-  annotation: PropTypes.object,
+  annotationSWGType: PropTypes.string,
+  annotationSWGStatus: PropTypes.string,
   isSelected: PropTypes.bool,
   isAnnotationModify: PropTypes.bool,
   handleStatusChange: PropTypes.func
@@ -18,7 +19,8 @@ const propTypes = {
 
 function SWGNoteSWGStatus(props) {
   const {
-    annotation,
+    annotationSWGType,
+    annotationSWGStatus,
     isSelected = false,
     handleStatusChange
   } = props;
@@ -32,14 +34,14 @@ function SWGNoteSWGStatus(props) {
       handleStatusChange(status, type);
     }
  };
- 
+
   return (
     <DataElementWrapper
       className="SWGNoteSWGStatus"
       dataElement="swgNoteSWGStatus"
     >
-       { (annotation.getCustomData("SWGtype") === "clarification") && 
-       (annotation.getCustomData("SWGstatus") === "none") && 
+       { (annotationSWGType === "clarification") &&
+       (annotationSWGStatus === "none") &&
        (<div class="swg-status-buttons">
           <div
             className="swg-status-agree-button"
@@ -61,8 +63,8 @@ function SWGNoteSWGStatus(props) {
           </div>
         </div>) }
           
-        { (annotation.getCustomData("SWGtype") === "revision") && 
-       (annotation.getCustomData("SWGstatus") === "none") && 
+        { (annotationSWGType === "revision") &&
+       (annotationSWGStatus === "none") &&
        (<div class="swg-status-buttons">
           <div
             className="swg-status-disagree-button"
@@ -75,8 +77,8 @@ function SWGNoteSWGStatus(props) {
           </div>
         </div>) }
 
-        { (annotation.getCustomData("SWGtype") === "modification") && 
-       (annotation.getCustomData("SWGstatus") === "none") && 
+        { (annotationSWGType === "modification") &&
+       (annotationSWGStatus === "none") &&
        (<div class="swg-status-buttons">
           <div
             className="swg-status-disagree-button"


### PR DESCRIPTION
Tracking these states as part of the `NoteContent` component allows type
and status changes to be tracked at the application level, and therefore
add them as dependencies to `useMemo` rendering, and therefore force
re-renders in child components of `NoteContent` when these properties
change via the UI

![swg](https://user-images.githubusercontent.com/16601729/110866111-7de8e200-8279-11eb-807c-814aa61e03d0.gif)
